### PR TITLE
Adding DSNRange (plus capacity to load doubles).

### DIFF
--- a/CustomBarnKit/default.cfg
+++ b/CustomBarnKit/default.cfg
@@ -106,6 +106,7 @@ CUSTOMBARNKIT
 		orbitDisplayMode = 2
 		patchesAheadLimit = 0, 2, 3
 		trackedObjectLimit = 0, 8, -1
+		DSNRange = 2000000000, 50000000000, 250000000000
 	}
 	
 	ADMINISTRATION

--- a/CustomGameVariables.cs
+++ b/CustomGameVariables.cs
@@ -110,6 +110,7 @@ namespace CustomBarnKit
         private float orbitDisplayMode = -1;
         private int[] patchesAheadLimit;
         private int[] trackedObjectLimit;
+		private double[] DSNRange;
 
         // Administration
         public int levelsAdministration = 3;
@@ -262,6 +263,7 @@ namespace CustomBarnKit
                 LoadValue(node, "orbitDisplayMode", ref orbitDisplayMode);
                 LoadValue(node, "patchesAheadLimit", ref patchesAheadLimit);
                 LoadValue(node, "trackedObjectLimit", ref trackedObjectLimit);
+				LoadValue(node, "DSNRange", ref DSNRange);
             }
 
             if (config.TryGetNode("ADMINISTRATION", ref node))
@@ -468,6 +470,17 @@ namespace CustomBarnKit
             return NormLevelToArrayValue(tsNormLevel, trackedObjectLimit);
         }
 
+		public override double GetDSNRange(float level)
+		{
+			if (DSNRange == null || DSNRange.Length != levelsTracking)
+			{
+				debugLog("DSNRange wrong size");
+				return original.GetDSNRange(level);
+			}
+
+			return NormLevelToArrayValue(level, DSNRange);
+		}
+
         // public override UntrackedObjectClass MinTrackedObjectSize(float tsNormLevel)
 
         //public override float ScoreFlightEnvelope(float altitude, float altEnvelope, float speed, float speedEnvelope)
@@ -661,6 +674,7 @@ namespace CustomBarnKit
             sb.AppendLine("orbitDisplayMode                   " + orbitDisplayMode.ToString("F2"));
             sb.AppendLine("patchesAheadLimit                  " + DumpArray(patchesAheadLimit));
             sb.AppendLine("trackedObjectLimit                 " + DumpArray(trackedObjectLimit));
+			sb.AppendLine("DSNRange                           " + DumpArray(DSNRange));
 
             sb.AppendLine("levelsAdministration               " + levelsAdministration);
             sb.AppendLine("upgradesAdministration             " + DumpArray(upgradesAdministration));
@@ -797,6 +811,36 @@ namespace CustomBarnKit
                 CustomBarnKit.log("No value " + key);
             }
         }
+
+		private static void LoadValue(ConfigNode node, string key, ref double[] param)
+		{
+			if (node.HasValue(key))
+			{
+				string s = node.GetValue(key);
+				string[] split = s.Split(',');
+				double[] result = new double[split.Length];
+
+				for (int i = 0; i < split.Length; i++)
+				{
+					string v = split[i];
+					double val;
+					if (double.TryParse(v, out val))
+					{
+						result[i] = val >= 0 ? val : double.MaxValue;
+					}
+					else
+					{
+						CustomBarnKit.log("Fail to parse \"" + s + "\" into a double array for key " + key);
+						return;
+					}
+				}
+				param = result;
+			}
+			else if (debug)
+			{
+				CustomBarnKit.log("No value " + key);
+			}
+		}
 
         private static void LoadValue(ConfigNode node, string key, ref int[] param)
         {


### PR DESCRIPTION
Known issue: the editor info for antennas seems to be hard-coded to assume 2G, 50G, 250G DSN ratings.  I understand that editor info is generated during part loading, which is before the solar system or anything else exists, so it can't know what ranges the DSN will have, but it may cause user confusion.  (The Space Center view correctly displays the modified DSN range.)