### PR TITLE
Fix facilities getting reset to lvl 1 in SB mode

### DIFF
--- a/CustomBarnKit.cs
+++ b/CustomBarnKit.cs
@@ -174,14 +174,15 @@ namespace CustomBarnKit
                 facility.UpgradeLevels = newUpgradeLevels;                
 
                 // Use the current save state to (re)init the facility
-                if (ScenarioUpgradeableFacilities.protoUpgradeables.TryGetValue( facility.id, out ScenarioUpgradeableFacilities.ProtoUpgradeable protoUpgradeable))
+                if (ScenarioUpgradeableFacilities.protoUpgradeables.TryGetValue( facility.id, out ScenarioUpgradeableFacilities.ProtoUpgradeable protoUpgradeable) &&
+                    protoUpgradeable.configNode != null)
                 {
                     facility.Load(protoUpgradeable.configNode);
                 }
                 else
                 {
                     facility.SetupLevels();
-                    facility.setLevel(facility.FacilityLevel);
+                    facility.setLevel(HighLogic.CurrentGame.Mode == Game.Modes.CAREER ? facility.FacilityLevel : facility.MaxLevel);
                 }
             }
             if (!varLoaded)


### PR DESCRIPTION
The main issue there is that `protoUpgradeable.configNode` is null in sandbox mode. Because of that `facility.Load()` will always set the facility level to 1. Then KSP itself will awake some frames later and overwrite the facility levels with it's own vision.